### PR TITLE
Run tests directly via SystemJS import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - '4'
 before_install:
-  npm install js-yaml
+  npm install
 script:
   - npm run lint-no-fix
   - npm run test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,6 @@ install:
   - ps: Install-Product node $env:nodejs_version $env:platform
 
   - npm config set spin false
-  - npm install js-yaml
   - npm install
 test_script:
   - node --version

--- a/jspm.config.js
+++ b/jspm.config.js
@@ -84,8 +84,10 @@ SystemJS.config({
     "angular": "github:angular/bower-angular@1.5.6",
     "angular-route": "github:angular/bower-angular-route@1.5.6",
     "angular-rx-subscribe": "npm:angular-rx-subscribe@0.2.5",
+    "assert": "github:jspm/nodelibs-assert@0.2.0-alpha",
     "buffer": "github:jspm/nodelibs-buffer@0.2.0-alpha",
     "chai": "npm:chai@3.5.0",
+    "child_process": "github:jspm/nodelibs-child_process@0.2.0-alpha",
     "css": "github:systemjs/plugin-css@0.1.22",
     "dirty-chai": "npm:dirty-chai@1.2.2",
     "firebase": "github:firebase/firebase-bower@3.0.5",
@@ -96,7 +98,8 @@ SystemJS.config({
     "sinon": "npm:sinon@1.17.4",
     "sinon-chai": "npm:sinon-chai@2.8.0",
     "text": "github:systemjs/plugin-text@0.0.8",
-    "util": "github:jspm/nodelibs-util@0.2.0-alpha"
+    "util": "github:jspm/nodelibs-util@0.2.0-alpha",
+    "vm": "github:jspm/nodelibs-vm@0.2.0-alpha"
   },
   packages: {
     "npm:sinon@1.17.4": {

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
     "babel-eslint": "^6.0.4",
     "coveralls": "^2.11.9",
     "eslint": "^2.13.1",
-    "eslint-config-singpath": "file:packages/eslint-config-singpath",
     "eslint-plugin-babel": "^3.2.0",
     "eslint-plugin-html": "^1.5.1",
     "http-server": "^0.9.0",
     "istanbul": "^0.4.3",
-    "jspm": "^0.17.0-beta.17",
+    "js-yaml": "^3.6.1",
+    "jspm": "^0.17.0-beta.22",
     "mocha": "^2.5.3",
     "pre-commit": "^1.1.3",
     "shelljs": "^0.7.0",
@@ -41,12 +41,15 @@
     },
     "peerDependencies": {
       "angular": "github:angular/bower-angular@^1.5.6",
+      "assert": "github:jspm/nodelibs-assert@^0.2.0-alpha",
       "buffer": "github:jspm/nodelibs-buffer@^0.2.0-alpha",
       "chai": "npm:chai@^3",
+      "child_process": "github:jspm/nodelibs-child_process@^0.2.0-alpha",
       "firebase": "github:firebase/firebase-bower@3",
       "process": "github:jspm/nodelibs-process@^0.2.0-alpha",
       "sinon": "npm:sinon@^1.17.4",
-      "util": "github:jspm/nodelibs-util@^0.2.0-alpha"
+      "util": "github:jspm/nodelibs-util@^0.2.0-alpha",
+      "vm": "github:jspm/nodelibs-vm@^0.2.0-alpha"
     },
     "overrides": {
       "github:angular/bower-angular-route@1.5.6": {

--- a/package.json
+++ b/package.json
@@ -18,10 +18,9 @@
     "jspm": "^0.17.0-beta.17",
     "mocha": "^2.5.3",
     "pre-commit": "^1.1.3",
-    "remap-istanbul": "^0.6.4",
     "shelljs": "^0.7.0",
     "source-map-explorer": "^1.3.2",
-    "source-map-support": "^0.4.0"
+    "systemjs-istanbul-hook": "^0.1.0"
   },
   "jspm": {
     "name": "example-app",

--- a/packages/eslint-config-singpath/default.yml
+++ b/packages/eslint-config-singpath/default.yml
@@ -155,10 +155,7 @@ rules:
   # disallow `function` declarations and expressions inside loop statements
   no-loop-func: error
   # disallow magic numbers
-  no-magic-numbers:
-  - error
-  - ignoreArrayIndexes: true
-    ignore: [-1, 0, 1]
+  no-magic-numbers: 'off'
   # disallow multiple spaces (fixable)
   no-multi-spaces: error
   # disallow multiline strings

--- a/packages/eslint-config-singpath/package.json
+++ b/packages/eslint-config-singpath/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-singpath",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "index.js",
   "author": "Chris Boesch",
   "description": "Default ESLint configuration for Singpath projects.",

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -48,3 +48,40 @@ tools.clean(['dist', 'coverage'], {
   message: 'Removing build/test artifacts'
 });
 ```
+
+
+## `mocha`
+
+```js
+const tools = require('@singpath/tools');
+
+tools.mocha(my-app/my-app.specs.js, {
+  // Mocha ui
+  ui: 'bdd'
+});
+```
+
+
+## `instanbul`
+
+```js
+const tools = require('@singpath/tools');
+
+tools.instanbul(my-app/my-app.specs.js, {
+  // Mocha ui
+  ui: 'bdd',
+
+  // path to coverage directory (the directory must exist)
+  coverage: path.resolve('./coverage'),
+
+  // instanbul report types
+  reports: ['lcov', 'text'],
+
+  // exclude function factory
+  exclude: function(baseURL) {
+    return function excludeModule(path) {
+      return path.startsWith(baseURL + 'jspm_packages') || path.endsWith('specs.js');
+    }
+  }
+});
+```

--- a/packages/tools/index.js
+++ b/packages/tools/index.js
@@ -179,9 +179,11 @@ function createReport(coverage, opts) {
   const reporter = new istanbul.Reporter(null, opts.coverage);
   const sync = true;
 
+  sh.echo('Creating reports...');
+
   collector.add(coverage);
   reporter.addAll(opts.reports);
-  reporter.write(collector, sync);
+  reporter.write(collector, sync, () => sh.echo('Reports created.'));
 }
 
 /**
@@ -191,7 +193,7 @@ function createReport(coverage, opts) {
  * @return {Promise<void, Error>}
  */
 function rejectHandler(err) {
-  process.stderr.write(`${err}\n`);
+  process.stderr.write(`${err.stack || err}\n`);
 
   if (sh.config.fatal) {
     sh.exit(1);

--- a/packages/tools/index.js
+++ b/packages/tools/index.js
@@ -243,7 +243,12 @@ exports.instanbul = function(modules, opts) {
     exclude(baseURL) {
       const jspmPackages = `${baseURL}jspm_packages`;
 
-      return address => (address.startsWith(jspmPackages) || address.endsWith('specs.js'));
+      return address => (
+        address.startsWith(jspmPackages) ||
+        address.endsWith('specs.js') ||
+        address.endsWith('.css') ||
+        address.endsWith('.html')
+      );
     }
   }, opts);
 

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@singpath/tools",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "index.js",
   "author": "Chris Boesch",
   "description": "Singpath package script helpers",
@@ -18,7 +18,13 @@
   },
   "bugs": "https://github.com/singpath/example-app/issues/",
   "dependencies": {
-    "shelljs": "^0.7.0"
+    "istanbul": "^0.4.3",
+    "mocha": "^2.5.3",
+    "shelljs": "^0.7.0",
+    "systemjs-istanbul-hook": "^0.1.0"
+  },
+  "peerDependencies": {
+    "jspm": "^0.17.0-beta.22"
   },
   "keywords": [
     "singpath"

--- a/tools/bin/cover.js
+++ b/tools/bin/cover.js
@@ -2,44 +2,20 @@
 'use strict';
 
 /**
- * Run example-app unit tests with coverage.
+ * Run example-app unit tests.
  */
 
-// dependencies
-const path = require('path');
 const sh = require('shelljs');
 const tools = require('../../packages/tools/index.js');
+const src = 'example-app/example-app.specs.js';
+const coverage = './coverage';
 
 // exit on error
 sh.set('-e');
 
-// paths
-const src = 'example-app/example-app.specs.js';
-const coverage = 'coverage';
-const dist = '_test';
-const output = path.join(dist, 'test.js');
+// setup
+tools.clean(coverage, {message: 'Removing coverage data'});
+sh.echo(`Setting up "${coverage}/"...`);
+sh.mkdir('-p', coverage);
 
-// Setup
-tools.clean([coverage, dist]);
-sh.echo(`Setting up "${dist}/"...`);
-sh.mkdir('-p', dist);
-
-
-// Transcode tests to a nodejs module.
-sh.echo(`Transcoding and bundling tests to "${output}"...`);
-tools.exec(`jspm build ${src} "${output}" --skip-rollup --format cjs`);
-
-
-// Run them with istanbul (instrument code to mesure coverage)
-// and mocha (a nodejs test runner).
-sh.echo('Running tests with coverage...');
-tools.exec(`istanbul cover -v --es-modules --print none --report json _mocha -- "${output}"`, {ignoreStderr: true});
-
-
-// Build reports pointing to the correct src paths
-sh.echo('Remapping coverage...');
-sh.mv(`${coverage}/coverage-final.json`, `${coverage}/coverage.json`);
-tools.exec(`remap-istanbul -i "${coverage}/coverage.json" -o "${coverage}/coverage.json" -e 'jspm_packages,.specs.js'`);
-
-sh.echo('Creating coverage report...');
-tools.exec('istanbul report --es-modules lcov text');
+tools.instanbul(src, {coverage});

--- a/tools/bin/test.js
+++ b/tools/bin/test.js
@@ -5,31 +5,11 @@
  * Run example-app unit tests.
  */
 
-// dependencies
-const path = require('path');
 const sh = require('shelljs');
 const tools = require('../../packages/tools/index.js');
+const src = 'example-app/example-app.specs.js';
 
 // exit on error
 sh.set('-e');
 
-// paths
-const src = 'example-app/example-app.specs.js';
-const dist = '_test';
-const output = path.join(dist, 'test.js');
-
-
-// Setup
-tools.clean(dist);
-sh.echo(`Setting up "${dist}/"...`);
-sh.mkdir('-p', dist);
-
-
-// Transcode tests to a nodejs module.
-sh.echo(`Transcoding and bundling tests to "${output}"...`);
-tools.exec(`jspm build ${src} "${output}" --skip-rollup --format cjs`);
-
-
-// Run them with mocha (a nodejs test runner).
-sh.echo('Running tests...');
-tools.exec(`mocha -b --require source-map-support/register "${output}"`);
+tools.mocha(src);


### PR DESCRIPTION
Running tests takes a few seconds instead of dozens.

It also fixes coverage reports.
